### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled command line

### DIFF
--- a/keyboardHandler.js
+++ b/keyboardHandler.js
@@ -1,4 +1,4 @@
-import { exec, execSync } from 'child_process';
+import { exec, execSync, execFile } from 'child_process';
 import { colors } from './colors.js';
 import inquirer from 'inquirer';
 import path from 'path';
@@ -190,7 +190,7 @@ class KeyboardHandler {
     }
     
     if (tokenAddress) {
-      exec(`open https://gmgn.ai/sol/token/${tokenAddress}`);
+      execFile('open', [`https://gmgn.ai/sol/token/${tokenAddress}`]);
       console.log(`Opening token address: https://gmgn.ai/sol/token/${tokenAddress}`);
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/facexyzploit/pumpsploit/security/code-scanning/3](https://github.com/facexyzploit/pumpsploit/security/code-scanning/3)

The best way to fix this problem is to avoid passing untrusted input to the shell. Instead of using `exec` with a string, use `execFile` (or `spawn`) and pass the URL as an argument array, which avoids shell interpretation. In this case, the command is `open` (on macOS), and the argument is the URL. This change should be made in the `handleOpenGMGN` method in `keyboardHandler.js`, replacing the use of `exec` with `execFile` and passing the URL as an argument. You will need to import `execFile` from `child_process` at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
